### PR TITLE
Fix for 'AskDeleteFile' dialog

### DIFF
--- a/Shoko.Desktop/Forms/AskDeleteFile.xaml.cs
+++ b/Shoko.Desktop/Forms/AskDeleteFile.xaml.cs
@@ -101,10 +101,17 @@ namespace Shoko.Desktop.Forms
                     FontWeight = FontWeights.DemiBold
                 };
                 CheckBox chk = new CheckBox { VerticalAlignment = VerticalAlignment.Center, IsChecked = true };
+                
                 chk.Checked += (a, b) =>
                 {
-                    chks[s] = chk.IsChecked.Value;
+                    chks[s] = true;
                 };
+
+                chk.Unchecked += (a, b) =>
+                {
+                    chks[s] = false;
+                };
+
                 st.Children.Add(im);
                 st.Children.Add(tx);
                 st.Children.Add(chk);


### PR DESCRIPTION
This fixes an issue with the 'AskDeleteFile' Dialog where by the state of the checkbox was not being read upon change/toggle which resulted in file deletion even when the checkbox was not selected / un-selected. 

Related to #604 