### PR TITLE
Fixed tracking on VLC + added playlist adds

### DIFF
--- a/Shoko.Desktop/VideoPlayers/VLCVideoPlayer.cs
+++ b/Shoko.Desktop/VideoPlayers/VLCVideoPlayer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -231,7 +231,7 @@ namespace Shoko.Desktop.VideoPlayers
                         {
                             // Extract filename and url decode so it matches
                             filename = HttpUtility.UrlDecode(fileRegex.Match(responseString).Groups[1].ToString());
-                            filename = filename.Replace("file:", string.Empty).Replace("/", "\\").Trim();
+                            filename = filename.Replace("file:///", string.Empty).Replace("/", "\\").Trim();
                         }
                     }
                 }

--- a/Shoko.Desktop/VideoPlayers/VLCVideoPlayer.cs
+++ b/Shoko.Desktop/VideoPlayers/VLCVideoPlayer.cs
@@ -68,19 +68,6 @@ namespace Shoko.Desktop.VideoPlayers
                 else
                 {
                     string init = $" {webUIParams}";
-                    // if (video.ResumePosition > 0)
-                    // {
-                    //     double n = video.ResumePosition;
-                    //     n /= 1000;
-                    //     init += " --start-time=\"" + n.ToString(CultureInfo.InvariantCulture) + "\"";
-                    // }
-                    // if (video.SubtitlePaths != null && video.SubtitlePaths.Count > 0)
-                    // {
-                    //     foreach (string s in video.SubtitlePaths)
-                    //     {
-                    //         init += " --sub-file=\"" + s + "\"";
-                    //     }
-                    // }
                     process = Process.Start(PlayerPath, init);
                     if (video.ResumePosition > 0)
                     {


### PR DESCRIPTION
Tracking of playback is fixed. Adding additional content will now add to playlist in VLC. Adjusted the initial start playback; not perfect but works with playlist.