### PR TITLE
Enable use of HTTPS

### DIFF
--- a/Shoko.Desktop/AppSettings.cs
+++ b/Shoko.Desktop/AppSettings.cs
@@ -298,6 +298,20 @@ namespace Shoko.Desktop
             }
         }
 
+        public static string JMMServer_Protocol
+        {
+            get
+            {
+                string val = Get("ShokoServer_Protocol");
+                if (!string.IsNullOrEmpty(val)) return val;
+                // default value
+                val = "http";
+                Set("ShokoServer_Protocol", val);
+                return val;
+            }
+            set => Set("ShokoServer_Protocol", value);
+        }
+
         public static string JMMServer_Address
         {
             get
@@ -1764,6 +1778,7 @@ namespace Shoko.Desktop
             logger.Info($"Episodes_WatchedStatus: {Episodes_WatchedStatus}");
             logger.Info($"BaseImagesPath: {BaseImagesPath}");
             logger.Info($"BaseImagesPathIsDefault: {BaseImagesPathIsDefault}");
+            logger.Info($"ShokoServer_Protocol: {JMMServer_Protocol}");
             logger.Info($"ShokoServer_Address: {JMMServer_Address}");
             logger.Info($"ShokoServer_Port: {JMMServer_Port}");
             logger.Info($"ShokoServer_FilePort: {JMMServer_FilePort}");

--- a/Shoko.Desktop/UserControls/Settings/JMMServerSettings.xaml
+++ b/Shoko.Desktop/UserControls/Settings/JMMServerSettings.xaml
@@ -11,6 +11,7 @@
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="Auto"/>
             <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
@@ -23,13 +24,17 @@
             <TextBlock Text="{Resx ResxName=Shoko.Commons.Properties.Resources, Key=Server}" Margin="0,0,5,2" VerticalAlignment="Center"></TextBlock>
             <TextBox Name="txtServer" Width="150" Margin="0,0,5,0" VerticalAlignment="Center"/>
         </StackPanel>
+        
+        <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="0">
+            <CheckBox Name="checkHttps" Content="HTTPS" Margin="0,0,5,2" HorizontalAlignment="Left" Grid.Column="2" VerticalAlignment="Top" IsChecked="False"></CheckBox>
+        </StackPanel>
 
-        <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="0" HorizontalAlignment="Right" Margin="0,0,5,0">
+        <StackPanel Orientation="Horizontal" Grid.Column="2" Grid.Row="0" HorizontalAlignment="Right" Margin="0,0,5,0">
             <TextBlock Text="{Resx ResxName=Shoko.Commons.Properties.Resources, Key=Port}" Margin="0,0,5,2" VerticalAlignment="Center"></TextBlock>
             <TextBox Name="txtPort" Width="50" Margin="0,0,5,0" VerticalAlignment="Center"/>
         </StackPanel>
 
-        <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="1"  HorizontalAlignment="Right" Visibility="Collapsed">
+        <StackPanel Orientation="Horizontal" Grid.Column="3" Grid.Row="1"  HorizontalAlignment="Right" Visibility="Collapsed">
             <TextBlock Text="{Resx ResxName=Shoko.Commons.Properties.Resources, Key=Settings_FilePort}" Margin="10,5,5,0" VerticalAlignment="Center"></TextBlock>
             <TextBox Name="txtFilePort" Width="50" Margin="0,5,5,0" VerticalAlignment="Center"/>
         </StackPanel>
@@ -45,7 +50,7 @@
             <TextBlock Text="{Resx ResxName=Shoko.Commons.Properties.Resources, Key=Proxy}" Margin="0,0,5,2" VerticalAlignment="Center"/>
             <TextBox Name="txtProxy" Width="245" Margin="0,0,5,0" VerticalAlignment="Center" />
         </StackPanel>
-        <CheckBox Name="btnAutoStartLocalJMMServer" Content="{Resx ResxName=Shoko.Commons.Properties.Resources, Key=Server_AutoStart}" Margin="0,2,0,0" HorizontalAlignment="Left" Grid.Column="2" VerticalAlignment="Top" IsChecked="True" Click="btnAutoStartLocalJMMServer_Click"/>
+        <CheckBox Name="btnAutoStartLocalJMMServer" Content="{Resx ResxName=Shoko.Commons.Properties.Resources, Key=Server_AutoStart}" Margin="0,2,0,0" HorizontalAlignment="Left" Grid.Column="3" VerticalAlignment="Top" IsChecked="True" Click="btnAutoStartLocalJMMServer_Click"/>
 
     </Grid>
 </UserControl>

--- a/Shoko.Desktop/UserControls/Settings/JMMServerSettings.xaml.cs
+++ b/Shoko.Desktop/UserControls/Settings/JMMServerSettings.xaml.cs
@@ -19,6 +19,7 @@ namespace Shoko.Desktop.UserControls.Settings
 
             Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo(AppSettings.Culture);
 
+            checkHttps.IsChecked = AppSettings.JMMServer_Protocol == "https";
             txtServer.Text = AppSettings.JMMServer_Address;
             txtPort.Text = AppSettings.JMMServer_Port;
             //txtFilePort.Text = AppSettings.JMMServer_FilePort;
@@ -33,6 +34,9 @@ namespace Shoko.Desktop.UserControls.Settings
         {
             try
             {
+                AppSettings.JMMServer_Protocol = (checkHttps.IsChecked.HasValue && checkHttps.IsChecked.Value)
+                    ? "https"
+                    : "http";
                 AppSettings.JMMServer_Address = txtServer.Text.Trim();
                 AppSettings.JMMServer_Port = txtPort.Text.Trim();
 

--- a/Shoko.Desktop/VideoPlayers/Extensions.cs
+++ b/Shoko.Desktop/VideoPlayers/Extensions.cs
@@ -97,7 +97,7 @@ namespace Shoko.Desktop.VideoPlayers
             name = WebUtility.UrlEncode(name);
 
             string uri =
-                $"http://{AppSettings.JMMServer_Address}:{AppSettings.JMMServer_Port}/Stream/{vlID}/{VM_ShokoServer.Instance.CurrentUser.JMMUserID}/false/{name}";
+                $"{AppSettings.JMMServer_Protocol}://{AppSettings.JMMServer_Address}:{AppSettings.JMMServer_Port}/Stream/{vlID}/{VM_ShokoServer.Instance.CurrentUser.JMMUserID}/false/{name}";
             string fname = Path.GetFileNameWithoutExtension(path);
             var p = m?.Parts?.FirstOrDefault();
             if (p?.Streams == null) return new Tuple<string, List<string>>(uri, subs);
@@ -109,7 +109,7 @@ namespace Shoko.Desktop.VideoPlayers
                 
                 try
                 {
-                    var url = $"http://{AppSettings.JMMServer_Address}:{AppSettings.JMMServer_Port}/Stream/Filename/{Base64EncodeUrl(s.File)}/{VM_ShokoServer.Instance.CurrentUser.JMMUserID}/false";
+                    var url = $"{AppSettings.JMMServer_Protocol}://{AppSettings.JMMServer_Address}:{AppSettings.JMMServer_Port}/Stream/Filename/{Base64EncodeUrl(s.File)}/{VM_ShokoServer.Instance.CurrentUser.JMMUserID}/false";
                     string subtitle = wc.DownloadString(url);
                     try
                     {

--- a/Shoko.Desktop/VideoPlayers/VideoHandler.cs
+++ b/Shoko.Desktop/VideoPlayers/VideoHandler.cs
@@ -445,7 +445,7 @@ namespace Shoko.Desktop.VideoPlayers
                 plsContent += @"[playlist]" + Environment.NewLine;
                 List<string> lines=new List<string>();
 
-                string url = $"http://{AppSettings.JMMServer_Address}:{AppSettings.JMMServer_Port}/Stream/%s/%s/false/%s";
+                string url = $"{AppSettings.JMMServer_Protocol}://{AppSettings.JMMServer_Address}:{AppSettings.JMMServer_Port}/Stream/%s/%s/false/%s";
 
                 for (int i = 1; i <= vids.Count; i++)
                 {

--- a/Shoko.Desktop/ViewModel/VM_ShokoServer.cs
+++ b/Shoko.Desktop/ViewModel/VM_ShokoServer.cs
@@ -109,6 +109,8 @@ namespace Shoko.Desktop.ViewModel
             if (string.IsNullOrEmpty(AppSettings.JMMServer_Address) || string.IsNullOrEmpty(AppSettings.JMMServer_Port))
                 return false;
 
+            if (!(AppSettings.JMMServer_Protocol.Equals("http") || AppSettings.JMMServer_Protocol.Equals("https")))
+                return false;
 
             return true;
         }
@@ -122,7 +124,7 @@ namespace Shoko.Desktop.ViewModel
 
             try
             {
-                _imageClient = ClientFactory.Create<IShokoServerImage>($"http://{AppSettings.JMMServer_Address}:{AppSettings.JMMServer_Port}/");
+                _imageClient = ClientFactory.Create<IShokoServerImage>($"{AppSettings.JMMServer_Protocol}://{AppSettings.JMMServer_Address}:{AppSettings.JMMServer_Port}/");
             }
             catch (Exception ex)
             {
@@ -139,7 +141,7 @@ namespace Shoko.Desktop.ViewModel
 
             try
             {
-                _plexClient = ClientFactory.Create<IShokoServerPlex>($"http://{AppSettings.JMMServer_Address}:{AppSettings.JMMServer_Port}/");
+                _plexClient = ClientFactory.Create<IShokoServerPlex>($"{AppSettings.JMMServer_Protocol}://{AppSettings.JMMServer_Address}:{AppSettings.JMMServer_Port}/");
             }
             catch (Exception ex)
             {
@@ -223,7 +225,7 @@ namespace Shoko.Desktop.ViewModel
 
                 _shokoservices =
                     ClientFactory.Create<IShokoServer>(
-                        $"http://{AppSettings.JMMServer_Address}:{AppSettings.JMMServer_Port}/", mappings, proxy:proxy);
+                        $"{AppSettings.JMMServer_Protocol}://{AppSettings.JMMServer_Address}:{AppSettings.JMMServer_Port}/", mappings, proxy:proxy);
                 // try connecting to see if the server is responding
                 Instance.ShokoServices.GetServerStatus();
                 ServerOnline = true;

--- a/Shoko.Desktop/testing.config
+++ b/Shoko.Desktop/testing.config
@@ -14,6 +14,7 @@
 	</rules>
   </nlog>
   <appSettings>
+  <add key="JMMServer_Protocol" value="http" />
 	<add key="JMMServer_Address" value="127.0.0.1" />
 	<add key="JMMServer_Port" value="8111" />
 	<add key="ImportFolderMappings" value="" />


### PR DESCRIPTION
This PR adds a checkbox in the connection UI to allow enabling HTTPS for connections.
A protocol setting is added and configured based on the checkbox.

This does mess up the neatly aligned UI right now, so maybe this needs to be revised.

Also, I've had trouble connecting with TLSv1.3, although TLSv1.2 worked fine.

Fixes #636
